### PR TITLE
[fix] quick links not displaying

### DIFF
--- a/src/components/LinkShare.vue
+++ b/src/components/LinkShare.vue
@@ -345,7 +345,7 @@ export default {
       }
     },
     addTracking(event, channel) {
-      this.shortLink = "";
+      this.shortLink = "[Not Generated]";
       this.longLink = tracking.addTracking(
         this.urlToShare,
         event,


### PR DESCRIPTION
Validation was preventing the quick links from showing the generated links view