### PR TITLE
adding `addTracking` custom event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1271,6 +1271,76 @@
         "postcss": "^7.0.0"
       }
     },
+    "@microsoft/applicationinsights-analytics-js": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.2.2.tgz",
+      "integrity": "sha512-69RCJPpZZhG/3FVBe0RiXPCXDBGzxtoHsty9kqlvqcS29Pzxz8B9abC/gSe8Ta1VixOcwIeUEUK/XwHYkRxL+Q==",
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.2.2",
+        "@microsoft/applicationinsights-core-js": "2.2.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@microsoft/applicationinsights-channel-js": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.2.2.tgz",
+      "integrity": "sha512-Gj4v6hoW+MA6ZHSFIfBxs7wj94nUOrteP861CPr8yzVxKSA04e15U78oYnQiJJFLQrG4wnuo/B/gMwDtj/3pyg==",
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.2.2",
+        "@microsoft/applicationinsights-core-js": "2.2.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@microsoft/applicationinsights-common": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.2.2.tgz",
+      "integrity": "sha512-jDci++srfxgqkcPPI6hUk0TPRRKpa1nhXxruBdHKlSAUezI9JSkA7s3yUp4JeUSPDOLPPRfepuHNjLcH0QhJsQ==",
+      "requires": {
+        "@microsoft/applicationinsights-core-js": "2.2.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@microsoft/applicationinsights-core-js": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.2.2.tgz",
+      "integrity": "sha512-iBFd7by50JFv7YjgmkM9B3c9AtLjyjSu+VEnWVV1QFUfA7qxBD+fJO8yNxt+qzEAnO7auE4ZvcHNi4PeaT/8+A==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "@microsoft/applicationinsights-dependencies-js": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.2.2.tgz",
+      "integrity": "sha512-ExESoscN6lrIBCpMfjlFATq02Gre7J5MG6VwdKfSNUwl0Ubkj9MEtC37IXBUiNT4SVHCMYElzVMUKXniXtPXdg==",
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.2.2",
+        "@microsoft/applicationinsights-core-js": "2.2.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@microsoft/applicationinsights-properties-js": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.2.2.tgz",
+      "integrity": "sha512-B6xbn9GtrdUwQvMM4EuQwztyzDO1PWod057bn0RHZU+y7MFQYEtNPVjCO+9+mfCNnSd973o80up2Gr87Fi5F6Q==",
+      "requires": {
+        "@microsoft/applicationinsights-common": "2.2.2",
+        "@microsoft/applicationinsights-core-js": "2.2.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@microsoft/applicationinsights-web": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.2.2.tgz",
+      "integrity": "sha512-9xaoehA1uGt02+Y9x2BJzzd9z6RYIpgzyArjp+OOLwUHs5B0Xj4SAwq5T2Gm1YADh2F3wrKTV/Y72KWIdJDfRg==",
+      "requires": {
+        "@microsoft/applicationinsights-analytics-js": "2.2.2",
+        "@microsoft/applicationinsights-channel-js": "2.2.2",
+        "@microsoft/applicationinsights-common": "2.2.2",
+        "@microsoft/applicationinsights-core-js": "2.2.2",
+        "@microsoft/applicationinsights-dependencies-js": "2.2.2",
+        "@microsoft/applicationinsights-properties-js": "2.2.2"
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -3468,7 +3538,8 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "coa": {
       "version": "2.0.2",
@@ -5926,7 +5997,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5947,12 +6019,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5967,17 +6041,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6094,7 +6171,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6106,6 +6184,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6120,6 +6199,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6127,12 +6207,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6151,6 +6233,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6231,7 +6314,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6243,6 +6327,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6328,7 +6413,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6364,6 +6450,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6383,6 +6470,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6426,12 +6514,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -7145,7 +7235,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ansi-styles": {
           "version": "3.2.1",
@@ -7192,6 +7283,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -10324,7 +10416,8 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
@@ -11694,8 +11787,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "@microsoft/applicationinsights-web": "^2.2.2",
     "axios": "^0.18.0",
     "localforage": "^1.7.3",
     "vue": "^2.6.10",

--- a/src/components/LinkShare.vue
+++ b/src/components/LinkShare.vue
@@ -387,6 +387,7 @@ export default {
       }
     },
     addTracking(event, channel) {
+      let ai = this.$appInsights;
       this.reloadSettings().then(() => {
         this.shortLink = "";
         this.longLink = tracking.addTracking(
@@ -395,6 +396,7 @@ export default {
           channel,
           this.alias
         );
+        ai.trackEvent({name: 'addTracking', properties: {event: event, channel: channel, alias: this.alias, url: this.urlToShare}});
       });
     },
     twitter() {

--- a/src/main.js
+++ b/src/main.js
@@ -11,10 +11,17 @@ import VueClipboard from 'vue-clipboard2';
 import Toasted from 'vue-toasted';
 import Vuelidate from 'vuelidate';
 
+import { ApplicationInsights } from '@microsoft/applicationinsights-web'
 import VueAppInsights from 'vue-application-insights'
 
+const appInsights = new ApplicationInsights({config: {
+  instrumentationKey: 'd8d11b38-ae34-4d38-b5cd-dab76f992722',
+  maxBatchInterval: 2000
+}});
+appInsights.loadAppInsights();
+
 Vue.use(VueAppInsights, {
-  id: 'd8d11b38-ae34-4d38-b5cd-dab76f992722',
+  appInsights: appInsights,  
   router
 })
 


### PR DESCRIPTION
Everytime someone click on a shorter link, it will log a custom event containing the `alias`, the `event`, the `channel`, and the `url`. 

This will allow us to query which channels/events are the most used.